### PR TITLE
Improved behavior and tests around PPU read buffer

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,7 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,9 @@ if (WITH_APP)
 
   set_property(TARGET ohNES PROPERTY CXX_STANDARD 17)
 
-  if (LINUX AND NOT APPLE)
-    set(GPERF_LIB profiler)
-  endif()
+  # if (LINUX AND NOT APPLE)
+  #   set(GPERF_LIB profiler)
+  # endif()
 
   target_link_libraries(ohNES
     ohNESCore

--- a/src/mappers/base_mapper.hpp
+++ b/src/mappers/base_mapper.hpp
@@ -163,7 +163,7 @@ protected:
     for (size_t i = 0; i < ppu_oam_.size(); ++i) {
       auto idx = (oam_base + i) & (ppu_oam_.size() - 1);
       assert(idx < ppu_oam_.size());
-      ppu_oam_[idx] = internal_[base | i];
+      ppu_oam_[idx] = read(base | i);
     }
     ppu_reg_.signalOamDma();
   }

--- a/src/mappers/cnrom.cpp
+++ b/src/mappers/cnrom.cpp
@@ -9,7 +9,14 @@ namespace mapper {
 
 void CNROM::cartWrite(AddressT addr, DataT data) {
   if (addr < 0x8000) {
-    // No Prg RAM available for this cartridge type
+    // NOTE(oren): CNROM hardware is not specified with any PRG RAM; however,
+    // some test roms might, so we map addresses in [0x6000, 0x8000) in the most
+    // straightforward way possible. Example: blargg's ppu_read_buffer test
+    // suite.
+    if (cart_.hasPrgRam) {
+      const AddressT PRG_RAM_MASK = cart_.prgRamSize - 1;
+      cart_.prgRam[addr & PRG_RAM_MASK] = data;
+    }
   } else { // 0x8000 <= addr < 0x10000
     chrBankSelect = data & 0b11;
   }
@@ -17,7 +24,12 @@ void CNROM::cartWrite(AddressT addr, DataT data) {
 
 CNROM::DataT CNROM::cartRead(AddressT addr) {
   if (addr < 0x8000) {
-    return 0;
+    if (cart_.hasPrgRam) {
+      const AddressT PRG_RAM_MASK = cart_.prgRamSize - 1;
+      return cart_.prgRam[addr & PRG_RAM_MASK];
+    } else {
+      return 0;
+    }
   } else {
     return cart_.prgRom[addr & (cart_.prgRomSize - 1)];
   }

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -399,13 +399,15 @@ void PPU::vBlankLine() {
     if (registers_.readPending()) {
       auto addr = registers_.vRamAddr();
       registers_.putData(readByte(addr));
+      // make sure we update the address bus after incrementing the vram addr
+      mapper_.setPpuABus(registers_.vRamAddr());
     } else if (registers_.writePending()) {
       auto addr = registers_.vRamAddr();
       auto data = registers_.getData();
       writeByte(addr, data);
+      mapper_.setPpuABus(registers_.vRamAddr());
     }
   }
-  mapper_.setPpuABus(registers_.vRamAddr());
 }
 
 bool PPU::rendering() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,7 @@ test_target(
   NAME ppu_test
   SRC src/ppu_tests.cpp
   ROMS ppu_vbl_nmi/rom_singles/*.nes
+  ROMS ppu_open_bus/ppu_open_bus.nes
   ROMS ppu_read_buffer/test_ppu_read_buffer.nes
 )
 

--- a/test/src/cpu_tests.cpp
+++ b/test/src/cpu_tests.cpp
@@ -45,9 +45,7 @@ TEST(CpuTest, BranchTiming) {
 
 TEST(CpuTest, DummyWrites) {
   BLARGG_TEST("rom/cpu_dummy_writes_oam.nes");
-
-  // NOTE(oren): requires open bus behavior to work correctly
-  // BLARGG_TEST("rom/cpu_dummy_writes_ppumem.nes");
+  BLARGG_TEST("rom/cpu_dummy_writes_ppumem.nes");
 }
 
 TEST(CpuTest, CpuReset) {

--- a/test/src/ppu_tests.cpp
+++ b/test/src/ppu_tests.cpp
@@ -1,25 +1,25 @@
 #include "test_util.hpp"
 
 TEST(PpuTest, VblNmi) {
-  BLARGG_TEST_MEM("rom/01-vbl_basics.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/02-vbl_set_time.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/03-vbl_clear_time.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/04-nmi_control.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/06-suppression.nes", 0x6000, 0x00);
+  BLARGG_TEST("rom/01-vbl_basics.nes");
+  BLARGG_TEST("rom/02-vbl_set_time.nes");
+  BLARGG_TEST("rom/03-vbl_clear_time.nes");
+  BLARGG_TEST("rom/04-nmi_control.nes");
+  BLARGG_TEST("rom/06-suppression.nes");
 }
 
-TEST(PpuTest, NmiTiming) {
-  // Failing test
-  BLARGG_TEST_MEM("rom/05-nmi_timing.nes", 0x6000, 0x01);
-  BLARGG_TEST_MEM("rom/07-nmi_on_timing.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/08-nmi_off_timing.nes", 0x6000, 0x00);
+TEST(PpuTest, DISABLED_NmiTiming) { BLARGG_TEST("rom/05-nmi_timing.nes"); }
+
+TEST(PpuTest, NmiOnOffTiming) {
+  BLARGG_TEST("rom/07-nmi_on_timing.nes");
+  BLARGG_TEST("rom/08-nmi_off_timing.nes");
 }
 
 TEST(PpuTest, VblNmiEvenOdd) {
-  BLARGG_TEST_MEM("rom/09-even_odd_frames.nes", 0x6000, 0x00);
-  BLARGG_TEST_MEM("rom/10-even_odd_timing.nes", 0x6000, 0x00);
+  BLARGG_TEST("rom/09-even_odd_frames.nes");
+  BLARGG_TEST("rom/10-even_odd_timing.nes");
 }
 
-TEST(PpuTest, DISABLED_PpuReadBuffer) {
-  BLARGG_TEST_MEM("rom/test_ppu_read_buffer.nes", 0x6000, 0x35);
-}
+TEST(PpuTest, PpuOpenBus) { BLARGG_TEST("rom/ppu_open_bus.nes"); }
+
+TEST(PpuTest, PpuReadBuffer) { BLARGG_TEST("rom/test_ppu_read_buffer.nes"); }

--- a/test/src/test_util.hpp
+++ b/test/src/test_util.hpp
@@ -21,7 +21,10 @@ bool is_test_complete(NES &nes, uint16_t result_base) {
       nes.mapper().read(result_base + 2, true),
       nes.mapper().read(result_base + 3, true),
   };
-  return std::strncmp((char *)mark, (char *)gold, 3) == 0 && status < 0x80;
+  bool valid = std::strncmp((char *)mark, (char *)gold, 3) == 0;
+  bool complete = valid && status < 0x80;
+
+  return complete;
 }
 
 void check_reset(NES &nes, uint16_t result_base, bool &requested,


### PR DESCRIPTION
- Implements PPU open bus behavior (with test)
- Improved relationship between PPUSCROLL ($2005) and PPUADDR ($2006) registers
  - write toggle behavior
  - VRAM address latched from T contents on 2nd $2006 write, but still stored separately
- Fixed VRAM increment which could overflow the 14-bit space
- Allow OAMDMA to read from ROM as well as PPU internal RAM
- Add blargg ppu_read_buffer test suite, which is pretty comprehensive

Also modifies CNROM mapper to accommodate a mapped PRG RAM. This is out of spec for the mapper but required to automate the ppu read buffer tests.

Bump CPU version to support certain dummy register reads.