### PR TITLE
Interrupt timing improvements

### DIFF
--- a/src/apu_registers.cpp
+++ b/src/apu_registers.cpp
@@ -54,8 +54,9 @@ uint8_t Registers::read(CName r, mapper::NESMapper &m) {
   if (r == STATUS) {
     clear_frame_interrupt_ = true;
     return fc_status_;
+  } else {
+    return m.openBus();
   }
-  return m.openBus();
 }
 
 void Registers::reload(CName r, mapper::NESMapper &m) {

--- a/src/mappers/base_mapper.hpp
+++ b/src/mappers/base_mapper.hpp
@@ -32,6 +32,10 @@ public:
   virtual bool setPpuABus(AddressT) = 0;
   virtual void tick(uint16_t) = 0;
   virtual uint8_t openBus(void) const = 0;
+  bool pendingIrq(void) const { return pending_irq_; };
+
+protected:
+  bool pending_irq_ = false;
 };
 
 template <class Derived> class NESMapperBase : public NESMapper {

--- a/src/mappers/mmc3.cpp
+++ b/src/mappers/mmc3.cpp
@@ -165,7 +165,6 @@ void MMC3::irqEnable(bool e) {
   // acknowledge whatever is pending
   if (irqEnabled_ && !e) {
     pending_irq_ = false;
-    console_.irqPin() = false;
   }
 
   irqEnabled_ = e;
@@ -177,7 +176,6 @@ bool MMC3::genIrq() {
     // std::cout << console_.currScanline() << ",  " << console_.currPpuCycle()
     //           << std::endl;
 
-    console_.irqPin() = true;
     pending_irq_ = true;
     return true;
   }

--- a/src/mappers/mmc3.hpp
+++ b/src/mappers/mmc3.hpp
@@ -64,7 +64,6 @@ private:
   } irqCounter_;
 
   bool irqEnabled_ = false;
-  bool pending_irq_ = false;
 
   enum class A12_STATE {
     LOW,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ test_target(
        cpu_reset/*.nes
        cpu_exec_space/*.nes
        instr_misc/rom_singles/*.nes
+       cpu_interrupts_v2/rom_singles/*.nes
 )
 
 test_target(

--- a/test/src/cpu_tests.cpp
+++ b/test/src/cpu_tests.cpp
@@ -67,3 +67,14 @@ TEST(CpuTest, DummyReads) {
   BLARGG_TEST("rom/03-dummy_reads.nes");
   BLARGG_TEST("rom/04-dummy_reads_apu.nes");
 }
+
+TEST(CpuTest, Interrupts) {
+  BLARGG_TEST("rom/1-cli_latency.nes");
+  BLARGG_TEST("rom/2-nmi_and_brk.nes");
+  BLARGG_TEST("rom/3-nmi_and_irq.nes");
+
+  // I note that both nestopia and nintendulator FAIL both of these tests,
+  // though in somewhat less catastrophic fashion than ohNES
+  // BLARGG_TEST("rom/4-irq_and_dma.nes");
+  // BLARGG_TEST("rom/5-branch_delays_irq.nes");
+}

--- a/test/src/ppu_tests.cpp
+++ b/test/src/ppu_tests.cpp
@@ -8,7 +8,7 @@ TEST(PpuTest, VblNmi) {
   BLARGG_TEST("rom/06-suppression.nes");
 }
 
-TEST(PpuTest, DISABLED_NmiTiming) { BLARGG_TEST("rom/05-nmi_timing.nes"); }
+TEST(PpuTest, NmiTiming) { BLARGG_TEST("rom/05-nmi_timing.nes"); }
 
 TEST(PpuTest, NmiOnOffTiming) {
   BLARGG_TEST("rom/07-nmi_on_timing.nes");


### PR DESCRIPTION
- Corrects (I think) some frame interrupt behavior where the IRQ line might not directly mirror the state of the frame interrupt flag
- Passes first three of blargg's interrupt timing tests (cpu_interrupts_v2)
  - 1-cli_latency.nes
  - 2-nmi_and_brk.nes
  - 3-nmi_and_irq.nes
  - For 1 & 2, core changes mostly to support M6502 changes
  - 3 required the frame interrupt improvements to work correctly
- Does not past tests 4 & 5 from the blargg suite, though neither does nestopia nor nintendulator. Leaving it along for now